### PR TITLE
Add support for MD3800, tested and verified

### DIFF
--- a/src/arrays.go
+++ b/src/arrays.go
@@ -7,6 +7,7 @@ const (
 	MD3200 Array = 3200
 	MD3220 Array = 3220
 	MD3460 Array = 3460
+	MD3800 Array = 3800
 )
 
 // Map arrays to strings for the CLI
@@ -14,4 +15,5 @@ var arrayIds = map[Array][]string{
 	MD3200: {"MD3200"},
 	MD3220: {"MD3220"},
 	MD3460: {"MD3460"},
+	MD3800: {"MD3800"},
 }

--- a/src/capabilities/capability.go
+++ b/src/capabilities/capability.go
@@ -152,6 +152,7 @@ const (
 	// public static final int CAPABILITY_REMOTE_MIRRORING_TYPE2 = 107;
 
 	// public static final int CAPABILITY_TOTAL_NUMBER_OF_ARVM_MIRRORS_PER_ARRAY = 109;
+	RemoteMirroring Capability = 109
 
 	// public static final int CAPABILITY_TOTAL_NUMBER_OF_PITS_PER_ARRAY = 110;
 	Snapshot Capability = 110

--- a/src/generator.go
+++ b/src/generator.go
@@ -65,6 +65,36 @@ func generate(device string, featureEnableIdentifier string, output string) erro
 		if err != nil {
 			return err
 		}
+	case "MD3800":
+		err = deviceLicence.AddFeature(capabilities.HighPerformanceTier, 0)
+		if err != nil {
+			return err
+		}
+
+		err = deviceLicence.AddFeature(capabilities.Snapshot, 256)
+		if err != nil {
+			return err
+		}
+
+		err = deviceLicence.AddFeature(capabilities.SsdCache, 0)
+		if err != nil {
+			return err
+		}
+
+		err = deviceLicence.AddFeature(capabilities.VirtualDiskCopy, 0)
+		if err != nil {
+			return err
+		}
+
+		err = deviceLicence.AddFeature(capabilities.PhysicalDiskSlots192, 0)
+		if err != nil {
+			return err
+		}
+
+		err = deviceLicence.AddFeature(capabilities.RemoteMirroring, 32)
+		if err != nil {
+			return err
+		}
 	default:
 		err = deviceLicence.AddFeature(capabilities.None, 0)
 		if err != nil {


### PR DESCRIPTION
Added support for the MD3800i SAN on the latest firmware published by Dell.  Unlocks every feature including remote replication.  