### PR TITLE
adding md3400 support, verified features

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,7 @@ The following arrays are supported:
 | Array | Enabled features |
 |-------|------------------|
 | MD3200<br/>MD3220 | &bull; Additional hard drives - 192 drives<br/>&bull; High performance tier<br/>&bull; Snapshots<br/>&bull; Snapshots plus virtual disk copy<br/>&bull; SSD cache<br/>&bull; Virtual disk copy |
+| MD3400 | &bull; Additional hard drives - 192 drives<br/>&bull; Data assurance<br/>&bull; High performance tier<br/>&bull; Snapshots<br/>&bull; SSD cache<br/>&bull; Virtual disk copy |
 | MD3460 | &bull; Additional hard drives - 180 drives<br/>&bull; Data assurance<br/>&bull; Snapshots<br/>&bull; Virtual disk copy |
 
 ### Tested arrays
@@ -48,5 +49,3 @@ This key generator has successfully been tested on the following arrays:
 
 - MD3200
 - MD3460
-
-

--- a/readme.md
+++ b/readme.md
@@ -48,4 +48,5 @@ The following arrays are supported:
 This key generator has successfully been tested on the following arrays:
 
 - MD3200
+- MD3400
 - MD3460

--- a/src/arrays.go
+++ b/src/arrays.go
@@ -6,6 +6,7 @@ type Array int
 const (
 	MD3200 Array = 3200
 	MD3220 Array = 3220
+	MD3400 Array = 3400
 	MD3460 Array = 3460
 )
 
@@ -13,5 +14,6 @@ const (
 var arrayIds = map[Array][]string{
 	MD3200: {"MD3200"},
 	MD3220: {"MD3220"},
+	MD3400: {"MD3400"},
 	MD3460: {"MD3460"},
 }

--- a/src/generator.go
+++ b/src/generator.go
@@ -45,6 +45,31 @@ func generate(device string, featureEnableIdentifier string, output string) erro
 		if err != nil {
 			return err
 		}
+	case "MD3400":
+		err = deviceLicence.AddFeature(capabilities.HighPerformanceTier, 0)
+		if err != nil {
+			return err
+		}
+
+		err = deviceLicence.AddFeature(capabilities.PhysicalDiskSlots192, 0)
+		if err != nil {
+			return err
+		}
+
+		err = deviceLicence.AddFeature(capabilities.Snapshot, 256)
+		if err != nil {
+			return err
+		}
+
+		err = deviceLicence.AddFeature(capabilities.SsdCache, 0)
+		if err != nil {
+			return err
+		}
+
+		err = deviceLicence.AddFeature(capabilities.VirtualDiskCopy, 0)
+		if err != nil {
+			return err
+		}
 	case "MD3460":
 		err = deviceLicence.AddFeature(capabilities.DataAssurance, 0)
 		if err != nil {


### PR DESCRIPTION
Tested validity against my own md3400 unit. Was able to activate all premium features and confirmed that while `Snapshots` is a valid feature, the `Snapshots plus virtual disk copy` is not.

![md3400-premium-features](https://github.com/user-attachments/assets/b19a2049-7e69-4929-93e6-d3f1077b8856)
